### PR TITLE
chore: pin GitHub Actions to commit SHAs

### DIFF
--- a/.github/actions/setup-node/action.yaml
+++ b/.github/actions/setup-node/action.yaml
@@ -3,9 +3,9 @@ name: setup-node
 runs:
   using: composite
   steps:
-    - uses: pnpm/action-setup@v4.2.0
+    - uses: pnpm/action-setup@41ff72655975bd51cab0327fa583b6e92b6d3061 # v4.2.0
 
-    - uses: actions/setup-node@v5.0.0
+    - uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444 # v5.0.0
       with:
         node-version-file: '.node-version'
         cache: 'pnpm'

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -15,7 +15,7 @@ jobs:
   build_and_test:
     runs-on: ubuntu-24.04
     steps:
-      - uses: actions/checkout@v5.0.0
+      - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
 
       - uses: ./.github/actions/setup-node
 
@@ -54,7 +54,7 @@ jobs:
       issues: write
       pull-requests: write
     steps:
-      - uses: actions/checkout@v5.0.0
+      - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
         with:
           fetch-depth: 0
           persist-credentials: false

--- a/.github/workflows/commitlint.yaml
+++ b/.github/workflows/commitlint.yaml
@@ -10,8 +10,8 @@ jobs:
   commitlint:
     runs-on: ubuntu-24.04
     steps:
-      - uses: actions/checkout@v5.0.0
+      - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
         with:
           fetch-depth: 0
 
-      - uses: wagoid/commitlint-github-action@v6
+      - uses: wagoid/commitlint-github-action@b948419dd99f3fd78a6548d48f94e3df7f6bf3ed # v6.2.1

--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -9,11 +9,11 @@ jobs:
   test:
     runs-on: ubuntu-24.04
     steps:
-      - uses: actions/checkout@v5.0.0
+      - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
 
       - name: Generate token
         id: generate_token
-        uses: actions/create-github-app-token@v2
+        uses: actions/create-github-app-token@67018539274d69449ef7c02e8e71183d1719ab42 # v2.1.4
         with:
           app-id: ${{ secrets.GH_APP_E2E_ID }}
           private-key: ${{ secrets.GH_APP_E2E_PRIVATE_KEY }}


### PR DESCRIPTION
## Summary

This PR pins all GitHub Actions references to specific commit SHAs for enhanced security and supply chain integrity.

**Background:**
Pinning actions to commit SHAs is a security best practice that prevents potential vulnerabilities from automatically pulling updated action versions. This approach ensures that workflows use verified, immutable versions of actions.

**Changes:**
- Pinned `actions/checkout@v5.0.0` to commit SHA `08c6903cd8c0fde910a37f88322edcfb5dd907a8`
- Pinned `actions/setup-node@v5.0.0` to commit SHA `a0853c24544627f65ddf259abe73b1d18a591444`
- Pinned `pnpm/action-setup@v4.2.0` to commit SHA `41ff72655975bd51cab0327fa583b6e92b6d3061`
- Pinned `actions/create-github-app-token@v2` to commit SHA `67018539274d69449ef7c02e8e71183d1719ab42` (v2.1.4)
- Pinned `wagoid/commitlint-github-action@v6` to commit SHA `b948419dd99f3fd78a6548d48f94e3df7f6bf3ed` (v6.2.1)

All version tags are preserved as comments for readability and future updates.

## References

- [GitHub Security Best Practices - Pinning Actions](https://docs.github.com/en/actions/security-for-github-actions/security-guides/security-hardening-for-github-actions#using-third-party-actions)
- n/a