### PR TITLE
chore: correct minimumReleaseAge format in Renovate config

### DIFF
--- a/renovate.json5
+++ b/renovate.json5
@@ -17,7 +17,7 @@
   rebaseLabel: 'S-needs-rebase',
 
   // Wait 7 days before creating PRs (aligned with pnpm-workspace.yaml)
-  minimumReleaseAge: 10080, // 7 days = 10080 minutes
+  minimumReleaseAge: '7 days',
 
   prConcurrentLimit: 0,
 


### PR DESCRIPTION
## Summary

This PR fixes the Renovate configuration error reported in issue #248. The `minimumReleaseAge` option was using a numeric value (`10080` minutes), but Renovate requires this to be specified as a string with time units.

**Changes:**
- Updated `minimumReleaseAge` from `10080` (numeric) to `'7 days'` (string format)
- Maintained the same 7-day waiting period for dependency updates
- Improved readability by using natural language duration format

**Background:**
Renovate was blocking all PRs due to this configuration validation error. The string format is the documented standard for time-based configuration options in Renovate, making it more readable and self-documenting compared to numeric minute values.

**Impact:**
Once merged, Renovate will resume normal operation and start creating dependency update PRs according to the configured schedule.

## References

- Fixes #248
- [Renovate Configuration Options](https://docs.renovatebot.com/configuration-options/)