### PR TITLE
chore: remove accidentally added dist/package-lock.json

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 /test.yaml
 /test.js
+/dist/package-lock.json
 
 # Created by https://www.toptal.com/developers/gitignore/api/osx,windows,node
 # Edit at https://www.toptal.com/developers/gitignore?templates=osx,windows,node
@@ -150,7 +151,7 @@ out
 .LSOverride
 
 # Icon must end with two \r
-Icon
+Icon
 
 # Thumbnails
 ._*

--- a/dist/package-lock.json
+++ b/dist/package-lock.json
@@ -1,6 +1,0 @@
-{
-  "name": "dist",
-  "lockfileVersion": 3,
-  "requires": true,
-  "packages": {}
-}


### PR DESCRIPTION
## Summary

This PR removes the `dist/package-lock.json` file that was accidentally added in PR #206 (commit 87e266e). 

### Background
The `dist/` directory contains the bundled output from `@vercel/ncc` and should only include:
- `index.js` (bundled output)
- `index.js.map` (source map)
- `licenses.txt` (license information)
- `package.json` (ES module marker containing only `{"type": "module"}`)
- `sourcemap-register.cjs`

The `package-lock.json` file in the `dist/` directory serves no purpose as there are no `node_modules` in this directory and it contains an empty lockfile with no dependencies.

### Changes
- Removed `dist/package-lock.json`
- Added `/dist/package-lock.json` to `.gitignore` to prevent future accidental commits

## References

- n/a