### PR TITLE
feat: support to sync dot files

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -92,6 +92,7 @@ const run = async (): Promise<number> => {
               const list = await glob('**/*', {
                 absolute: false,
                 onlyFiles: true,
+                dot: true,
                 cwd: path.join(cwd, file.from),
               });
               paths = list.map((p) => [path.join(file.from, p), path.join(file.to, p)]);


### PR DESCRIPTION
fast-glob does not support dot files by default, so we would like to support them unless there is a specific reason not to.

ref. https://github.com/mrmlnc/fast-glob?tab=readme-ov-file#dot
close #215 