### PR TITLE
fix: allow committing only generated dist files

### DIFF
--- a/lefthook.yaml
+++ b/lefthook.yaml
@@ -7,7 +7,7 @@ pre-commit:
       stage_fixed: true
     oxlint:
       glob: '*.{js,ts,tsx}'
-      run: npx oxlint {staged_files}
+      run: npx oxlint --no-error-on-unmatched-pattern {staged_files}
 
 commit-msg:
   commands:


### PR DESCRIPTION
## Summary

Committing a change that touches only `dist/` was rejected by the `pre-commit` hook.

`lefthook.yaml` passes staged files matching `*.{js,ts,tsx}` to oxlint, which includes `dist/index.js`. Since `dist/` is listed in `ignorePatterns` in `.oxlintrc.json`, oxlint ends up with no files to inspect and exits 1:

```
No files found to lint. Please check your paths and ignore patterns.
```

oxlint 1.22 exited 0 in this situation, so the problem only became visible after the upgrade to 1.79 in #259. It blocks the routine flow of rebuilding the bundle and committing `dist/` on its own.

Adding `--no-error-on-unmatched-pattern` makes oxlint exit 0 when every given path is excluded, while still reporting real violations for files that are actually linted.

## Verification

Staging a modified `dist/index.js` alone and committing:

- before the change: rejected by the pre-commit hook
- after the change: commit succeeds

Linting of non-ignored files is unaffected — `pnpm lint` still reports violations as before.