### PR TITLE
feat: run the action on the Node 24 runtime

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: wadackel/files-sync-action@v3
+      - uses: wadackel/files-sync-action@v4
         with:
           github_token: ${{ secrets.GH_FILES_SYNC_TOKEN }}
 ```
@@ -79,7 +79,7 @@ jobs:
           app-id: ${{ secrets.GH_APP_ID }}
           private-key: ${{ secrets.GH_APP_PRIVATE_KEY }}
           # Optional: Set the permissions for the token (e.g. "owner", "repositories")
-      - uses: wadackel/files-sync-action@v3
+      - uses: wadackel/files-sync-action@v4
         with:
           github_token: ${{ steps.generate_token.outputs.token }}
 ```

--- a/action.yaml
+++ b/action.yaml
@@ -23,5 +23,5 @@ outputs:
     description: 'An array of all synchronized file names.'
 
 runs:
-  using: 'node20'
+  using: 'node24'
   main: 'dist/index.js'


### PR DESCRIPTION
## Summary

Switches `runs.using` in `action.yaml` from `node20` to `node24`.

GitHub is removing the Node 20 execution runtime from Actions runners in September 2026. GitHub-hosted runners already force `node20` actions to execute on Node 24, so for those consumers this only aligns the manifest with what already happens at run time.

## Compatibility

`node24` requires **runner v2.327.1 or newer**. All GitHub-hosted runners meet this. Self-hosted runners and GitHub Enterprise Server installations on an older runner must be updated before upgrading.

Released as a major version. The manifest value only changes behaviour on runners that do not already force Node 24 — that is, exactly the older runners this would break. Shipping it as a minor would break those consumers on their next run with no way to opt out, while giving GitHub-hosted consumers nothing they do not already have. A major lets the affected group upgrade on their own schedule; `v3` keeps working for them in the meantime.

## Verification

- `pnpm build` produces no change to `dist/` — only action metadata changes.
- `pnpm test`, `pnpm lint`, `pnpm typecheck` pass, and `pnpm generate` produces no further diff.
- The bundled `dist/index.js` was executed directly on Node 24.19.0 and started correctly, emitting the expected `::error::` annotation for a missing config file.