### PR TITLE
chore: enable Renovate lock file maintenance

### DIFF
--- a/renovate.json5
+++ b/renovate.json5
@@ -21,6 +21,16 @@
 
   prConcurrentLimit: 0,
 
+  // Version updates alone never refresh the lockfile, so a caret range that already
+  // permits a fixed release keeps resolving to the version it first locked. Refresh
+  // weekly instead. A refresh that moves a runtime dependency changes dist/index.js,
+  // so the branch fails CI until dist/ is rebuilt by hand; commit that rebuild as
+  // `fix:` to release the corrected bundle.
+  lockFileMaintenance: {
+    enabled: true,
+    automerge: false,
+  },
+
   packageRules: [
     // GitHub Actions packages
     {


### PR DESCRIPTION
## Summary

Addresses the cause behind #282 and #283 rather than the symptom.

Renovate only proposes changes when a **manifest range** needs to move. `micromatch: '^4.0.5'` already permits 4.0.8, so Renovate correctly concluded there was nothing to update — and never refreshed the lockfile, which kept resolving to 4.0.5. Four runtime dependencies sat on their 2023 resolutions that way, with the vulnerable versions bundled into the released `dist/index.js` the whole time. Nothing in the current configuration would have surfaced that.

`lockFileMaintenance` closes the gap by refreshing the lockfile wholesale on a schedule, independent of whether any range changed.

```json5
lockFileMaintenance: {
  enabled: true,
  automerge: false,
},
```

`schedule` is left at its default (weekly, before 4am Monday). The 7-day age guard still applies: `lockFileMaintenance` works by removing the lockfile and re-running the package manager, so `minimumReleaseAge: 10080` in `pnpm-workspace.yaml` gates resolution. The existing `group:*` presets are unaffected — this is a separate update type on its own branch, producing one consolidated PR per window.

## What this does not do

It does not make security fixes land unattended, and the comment in the config says so.

CI fails when `pnpm build` leaves `dist/` dirty, and Renovate never rebuilds the bundle. Any refresh that moves a runtime dependency therefore turns the branch red until a maintainer checks it out, runs `pnpm build` and commits `dist/`. Past dependency PRs needed exactly that step. `automerge` is set to `false` explicitly to record that it cannot work here rather than leaving it to the default.

What the change buys is that the staleness becomes visible every week instead of never.

## Commit type

Left at the repository-wide `chore:`. Overriding it to `fix:` was considered and rejected: most refreshes move only devDependency transitives and leave `dist/` untouched, so it would cut an empty patch release every week. The release should instead come from the dist rebuild commit, which only exists when the bundle actually changed and which a human already has to write — the config comment records that convention.